### PR TITLE
Feedback improvements

### DIFF
--- a/Source/Anchorpoint/Private/AnchorpointSourceControlProvider.cpp
+++ b/Source/Anchorpoint/Private/AnchorpointSourceControlProvider.cpp
@@ -206,7 +206,7 @@ ECommandResult::Type FAnchorpointSourceControlProvider::Execute(const FSourceCon
 	// ToImplement: Everything in this function needs to be checked 
 
 	// Only Connect operation allowed while not Enabled (Connected)
-	if (!IsEnabled() && !(InOperation->GetName() == "Connect"))
+	if (!IsEnabled() && InOperation->GetName() != "Connect")
 	{
 		(void)InOperationCompleteDelegate.ExecuteIfBound(InOperation, ECommandResult::Failed);
 		return ECommandResult::Failed;

--- a/Source/Anchorpoint/Public/AnchorpointSourceControlProvider.h
+++ b/Source/Anchorpoint/Public/AnchorpointSourceControlProvider.h
@@ -61,6 +61,7 @@ public:
 	virtual TSharedRef<SWidget> MakeSettingsWidget() const override;
 	//~ End ISourceControlProvider Interface
 
+	void TickDuringModal(float DeltaTime);
 	void HandlePackageSaved(const FString& InPackageFilename, UPackage* InPackage, FObjectPostSaveContext InObjectSaveContext);
 	void RefreshStatus();
 
@@ -81,6 +82,7 @@ public:
 
 	FTimerHandle RefreshTimerHandle;
 	float RefreshDelay = 1.0f;
+	bool bSubmitModalActive = false;
 };
 
 template <typename Type>

--- a/Source/AnchorpointCli/AnchorpointCli.Build.cs
+++ b/Source/AnchorpointCli/AnchorpointCli.Build.cs
@@ -19,6 +19,7 @@ public class AnchorpointCli : ModuleRules
 			"SlateCore",
 			"SourceControl", 
 			"UnrealEd",
+			"ToolMenus",
 			"UnsavedAssetsTracker",
 		});
 	}

--- a/Source/AnchorpointCli/Private/AnchorpointCliCommands.cpp
+++ b/Source/AnchorpointCli/Private/AnchorpointCliCommands.cpp
@@ -4,6 +4,7 @@
 
 #include <Serialization/JsonSerializer.h>
 #include <Async/Async.h>
+#include <ProfilingDebugging/ScopedTimers.h>
 
 #include "AnchorpointCliLog.h"
 #include "AnchorpointCliProcess.h"
@@ -132,6 +133,8 @@ FString AnchorpointCliCommands::ConvertCommandToIni(const FString& InCommand, bo
 FCliResult AnchorpointCliCommands::RunApCommand(const FCliParameters& InParameters)
 {
 	TRACE_CPUPROFILER_EVENT_SCOPE(RunApCli);
+
+	UE_SCOPED_TIMER(TEXT("AnchorpointCliCommands::RunApCommand"), LogAnchorpointCli, Verbose);
 
 	TSharedRef<FAnchorpointCliProcess> Process = MakeShared<FAnchorpointCliProcess>();
 

--- a/Source/AnchorpointCli/Private/AnchorpointCliConnectSubsystem.cpp
+++ b/Source/AnchorpointCli/Private/AnchorpointCliConnectSubsystem.cpp
@@ -13,7 +13,7 @@
 #include <SourceControlOperations.h>
 #include <UnsavedAssetsTrackerModule.h>
 #include <Widgets/Notifications/SNotificationList.h>
-#include <Kismet/KismetStringLibrary.h>
+#include <LevelEditor.h>
 
 #include "AnchorpointCli.h"
 #include "AnchorpointCliLog.h"
@@ -127,6 +127,9 @@ void UAnchorpointCliConnectSubsystem::Initialize(FSubsystemCollectionBase& Colle
 		FConsoleCommandWithWorldArgsAndOutputDeviceDelegate::CreateUObject(this, &UAnchorpointCliConnectSubsystem::OnFakeAnchorpointCliMessage),
 		ECVF_Default
 	);
+
+	FLevelEditorModule& LevelEditorModule = FModuleManager::LoadModuleChecked<FLevelEditorModule>("LevelEditor");
+	LevelEditorModule.OnLevelEditorCreated().AddUObject(this, &UAnchorpointCliConnectSubsystem::OnLevelEditorCreated);
 }
 
 void UAnchorpointCliConnectSubsystem::Deinitialize()
@@ -533,4 +536,42 @@ void UAnchorpointCliConnectSubsystem::ToastConnectionState(bool bConnected)
 	Info->Image = bConnected ? ConnectBrush : DisconnectBrush;
 
 	FSlateNotificationManager::Get().QueueNotification(Info);
+}
+
+void UAnchorpointCliConnectSubsystem::OnLevelEditorCreated(TSharedPtr<ILevelEditor> LevelEditor)
+{
+	UToolMenu* LevelEditorStatusBar = UToolMenus::Get()->ExtendMenu("LevelEditor.StatusBar.ToolBar");
+	FToolMenuSection& Section = LevelEditorStatusBar->FindOrAddSection("SourceControl");
+
+	TSharedRef<SBox> StatusImage = SNew(SBox)
+		.HAlign(HAlign_Center)
+		[
+			SNew(SImage)
+			.DesiredSizeOverride(CoreStyleConstants::Icon16x16)
+			.Image_UObject(this, &UAnchorpointCliConnectSubsystem::GetDrawerIcon)
+			.ToolTipText_UObject(this, &UAnchorpointCliConnectSubsystem::GetDrawerText)
+		];
+
+	FToolMenuEntry StatusIconEntry = FToolMenuEntry::InitWidget("AnchorpointStatus", StatusImage, FText::GetEmpty(), true, false);
+	Section.AddEntry(StatusIconEntry);
+}
+
+const FSlateBrush* UAnchorpointCliConnectSubsystem::GetDrawerIcon() const
+{
+	if (!IsConnected())
+	{
+		return FAppStyle::GetBrush(TEXT("MessageLog.Warning"));
+	}
+
+	return nullptr;
+}
+
+FText UAnchorpointCliConnectSubsystem::GetDrawerText() const
+{
+	if (!IsConnected())
+	{
+		return NSLOCTEXT("Anchorpoint", "DrawerDisconnected", "Anchorpoint CLI is not connected. To make Source Control commands faster, open the desktop app.");
+	}
+
+	return NSLOCTEXT("Anchorpoint", "DrawerConnected", "Anchorpoint CLI is connected. Source Control commands will run faster.");
 }

--- a/Source/AnchorpointCli/Private/AnchorpointCliConnectSubsystem.cpp
+++ b/Source/AnchorpointCli/Private/AnchorpointCliConnectSubsystem.cpp
@@ -570,8 +570,8 @@ FText UAnchorpointCliConnectSubsystem::GetDrawerText() const
 {
 	if (!IsConnected())
 	{
-		return NSLOCTEXT("Anchorpoint", "DrawerDisconnected", "Anchorpoint CLI is not connected. To make Source Control commands faster, open the desktop app.");
+		return NSLOCTEXT("Anchorpoint", "DrawerDisconnected", "Keep the Anchorpoint project open (or minimized) to maintain better connectivity.");
 	}
 
-	return NSLOCTEXT("Anchorpoint", "DrawerConnected", "Anchorpoint CLI is connected. Source Control commands will run faster.");
+	return FText::GetEmpty();
 }

--- a/Source/AnchorpointCli/Public/AnchorpointCliConnectSubsystem.h
+++ b/Source/AnchorpointCli/Public/AnchorpointCliConnectSubsystem.h
@@ -8,6 +8,7 @@
 
 #include "AnchorpointCliConnectSubsystem.generated.h"
 
+class ILevelEditor;
 class FAnchorpointCliProcess;
 /**
  * Structure of the JSON messages received from the Anchorpoint CLI connect
@@ -137,6 +138,18 @@ private:
 	 * Displays a toast message indicating the connection state
 	 */
 	void ToastConnectionState(bool bConnected);
+	/**
+	 * Callback executed when the level editor creation is finished
+	 */
+	void OnLevelEditorCreated(TSharedPtr<ILevelEditor> LevelEditor);
+	/**
+	 * Callback executed to determine what icon should be shown next to the revision control status bar
+	 */
+	const FSlateBrush* GetDrawerIcon() const;
+	/**
+	 * Callback executed to determine what tooltip text should be shown for the icon next to the revision control status bar 
+	 */
+	FText GetDrawerText() const;
 	/**
 	 * The process that is running the Anchorpoint CLI connect command
 	 */


### PR DESCRIPTION
As per user feedback:
- added warning icon permanently to status bar when CLI is not connected
- added scoped timer to measure duration for each CLI command
- disable the "Keep Files Checked Out" toggle during submit