### PR TITLE
Refactor cached status patching to access internal state

### DIFF
--- a/Source/Anchorpoint/Private/AnchorpointSourceControlOperations.cpp
+++ b/Source/Anchorpoint/Private/AnchorpointSourceControlOperations.cpp
@@ -244,7 +244,8 @@ bool FAnchorpointConnectWorker::Execute(FAnchorpointSourceControlCommand& InComm
 		          }
 	          });
 
-	FAnchorpointCliModule::Get().OnAnchorpointConnected.Broadcast();
+	FAnchorpointSourceControlProvider& Provider = FAnchorpointModule::Get().GetProvider();
+	Provider.OnConnected();
 
 	InCommand.bCommandSuccessful = true;
 	return InCommand.bCommandSuccessful;

--- a/Source/Anchorpoint/Private/AnchorpointSourceControlProvider.cpp
+++ b/Source/Anchorpoint/Private/AnchorpointSourceControlProvider.cpp
@@ -486,6 +486,14 @@ TSharedRef<SWidget> FAnchorpointSourceControlProvider::MakeSettingsWidget() cons
 	return SNew(SAnchorpointSourceControlSettingsWidget);
 }
 
+void FAnchorpointSourceControlProvider::OnConnected()
+{
+	if (UAnchorpointCliConnectSubsystem* ConnectSubsystem = GEditor->GetEditorSubsystem<UAnchorpointCliConnectSubsystem>())
+	{
+		ConnectSubsystem->RefreshConnection();
+	}
+}
+
 void FAnchorpointSourceControlProvider::OnStatesChanged()
 {
 	// List of files we already warned the user about - once this file is spotted with a non-conflicting state,

--- a/Source/Anchorpoint/Private/AnchorpointSourceControlProvider.cpp
+++ b/Source/Anchorpoint/Private/AnchorpointSourceControlProvider.cpp
@@ -10,8 +10,10 @@
 #include <FileHelpers.h>
 #include <Interfaces/IPluginManager.h>
 
+#include "AnchorpointCli.h"
 #include "AnchorpointCliConnectSubsystem.h"
 #include "AnchorpointCliOperations.h"
+#include "AnchorpointCliStatus.h"
 #include "AnchorpointHacks.h"
 #include "AnchorpointLog.h"
 #include "AnchorpointPopup.h"
@@ -490,6 +492,9 @@ void FAnchorpointSourceControlProvider::OnConnected()
 {
 	if (UAnchorpointCliConnectSubsystem* ConnectSubsystem = GEditor->GetEditorSubsystem<UAnchorpointCliConnectSubsystem>())
 	{
+		ConnectSubsystem->OnAssetSavedPatchStatus.BindRaw(this, &FAnchorpointSourceControlProvider::OnAssetSavedPatchStatus);
+		ConnectSubsystem->OnMessageReceivedPatchStatus.BindRaw(this, &FAnchorpointSourceControlProvider::OnMessageReceivedPatchStatus);
+
 		ConnectSubsystem->RefreshConnection();
 	}
 }
@@ -588,6 +593,69 @@ TSharedPtr<IAnchorpointSourceControlWorker> FAnchorpointSourceControlProvider::C
 	}
 
 	return nullptr;
+}
+
+bool FAnchorpointSourceControlProvider::OnAssetSavedPatchStatus(FAnchorpointStatus& InOutStatus, const FString& InPackageFilename)
+{
+	ISourceControlProvider& Provider = ISourceControlModule::Get().GetProvider();
+	FSourceControlStatePtr State = Provider.GetState(InPackageFilename, EStateCacheUsage::Use);
+
+	if (!State)
+	{
+		return false; // We cannot reason about this asset without knowing it's state.
+	}
+
+	if (State->IsAdded())
+	{
+		// Re-saving an added asset won't change its state. It might change it from AddedInMemory to Added (on disk) but nothing else.
+		if (!InOutStatus.Staged.Contains(InPackageFilename) && !InOutStatus.NotStaged.Contains(InPackageFilename))
+		{
+			InOutStatus.NotStaged.Add(InPackageFilename, EAnchorpointFileOperation::Added);
+		}
+
+		return true;
+	}
+
+	if (!State->IsModified())
+	{
+		// Re-saving an unchanged asset will certainly mark it as modified.
+		InOutStatus.NotStaged.Add(InPackageFilename, EAnchorpointFileOperation::Modified);
+
+		return true;
+	}
+
+	return false;
+}
+
+bool FAnchorpointSourceControlProvider::OnMessageReceivedPatchStatus(FAnchorpointStatus& InOutStatus, const FAnchorpointConnectMessage& InMessage)
+{
+	const FString& MessageType = InMessage.Type;
+
+	if (MessageType == TEXT("files locked") || MessageType == TEXT("files unlocked"))
+	{
+		TValueOrError<FAnchorpointLocks, FString> Locks = AnchorpointCliOperations::GetLockedFiles();
+		if (!Locks.HasValue())
+		{
+			return false; // Command failed, no usable result available
+		}
+
+		InOutStatus.Locked = Locks.GetValue();
+		return true;
+	}
+
+	if (MessageType == TEXT("files outdated") || MessageType == TEXT("files updated"))
+	{
+		TValueOrError<FAnchorpointOutdated, FString> Outdated = AnchorpointCliOperations::GetOutdatedFiles();
+		if (!Outdated.HasValue())
+		{
+			return false; // Command failed, no usable result available
+		}
+
+		InOutStatus.Outdated = Outdated.GetValue();
+		return true;
+	}
+
+	return false;
 }
 
 void FAnchorpointSourceControlProvider::OutputCommandMessages(const FAnchorpointSourceControlCommand& InCommand) const

--- a/Source/Anchorpoint/Private/AnchorpointSourceControlProvider.cpp
+++ b/Source/Anchorpoint/Private/AnchorpointSourceControlProvider.cpp
@@ -494,6 +494,7 @@ void FAnchorpointSourceControlProvider::OnConnected()
 	{
 		ConnectSubsystem->OnAssetSavedPatchStatus.BindRaw(this, &FAnchorpointSourceControlProvider::OnAssetSavedPatchStatus);
 		ConnectSubsystem->OnMessageReceivedPatchStatus.BindRaw(this, &FAnchorpointSourceControlProvider::OnMessageReceivedPatchStatus);
+		ConnectSubsystem->OnInMemoryAssetCreatedPatchStatus.BindRaw(this, &FAnchorpointSourceControlProvider::OnInMemoryAssetCreatedPatchStatus);
 
 		ConnectSubsystem->RefreshConnection();
 	}
@@ -671,6 +672,20 @@ bool FAnchorpointSourceControlProvider::OnMessageReceivedPatchStatus(FAnchorpoin
 	}
 
 	return false;
+}
+
+bool FAnchorpointSourceControlProvider::OnInMemoryAssetCreatedPatchStatus(FAnchorpointStatus& InOutStatus, UObject* InAsset)
+{
+	const auto Package = InAsset ? InAsset->GetPackage() : nullptr;
+	if (!Package)
+	{
+		return false;
+	}
+
+	const FString Filename = USourceControlHelpers::PackageFilename(Package);
+	InOutStatus.NotStaged.Add(Filename, EAnchorpointFileOperation::Added);
+
+	return true;
 }
 
 void FAnchorpointSourceControlProvider::OutputCommandMessages(const FAnchorpointSourceControlCommand& InCommand) const

--- a/Source/Anchorpoint/Private/AnchorpointSourceControlProvider.cpp
+++ b/Source/Anchorpoint/Private/AnchorpointSourceControlProvider.cpp
@@ -630,11 +630,13 @@ bool FAnchorpointSourceControlProvider::OnAssetSavedPatchStatus(FAnchorpointStat
 		return true;
 	}
 
-	if (State->State == EAnchorpointState::UnlockedUnchanged)
+	if (State->State == EAnchorpointState::LockedUnchanged || State->State == EAnchorpointState::UnlockedUnchanged)
 	{
 		// Re-saving an unchanged asset will certainly mark it as modified. 
 		// At this point we cannot reason if it's LockedModified or UnlockedModified.
 		InOutStatus.NotStaged.Add(InPackageFilename, EAnchorpointFileOperation::Modified);
+ 
+		return true;
 	}
 
 	return false;

--- a/Source/Anchorpoint/Private/AnchorpointSourceControlProvider.cpp
+++ b/Source/Anchorpoint/Private/AnchorpointSourceControlProvider.cpp
@@ -598,16 +598,24 @@ TSharedPtr<IAnchorpointSourceControlWorker> FAnchorpointSourceControlProvider::C
 bool FAnchorpointSourceControlProvider::OnAssetSavedPatchStatus(FAnchorpointStatus& InOutStatus, const FString& InPackageFilename)
 {
 	ISourceControlProvider& Provider = ISourceControlModule::Get().GetProvider();
-	FSourceControlStatePtr State = Provider.GetState(InPackageFilename, EStateCacheUsage::Use);
+	FSourceControlStatePtr PackageState = Provider.GetState(InPackageFilename, EStateCacheUsage::Use);
 
-	if (!State)
+	if (!PackageState)
 	{
 		return false; // We cannot reason about this asset without knowing it's state.
 	}
 
-	if (State->IsAdded())
+	const TSharedPtr<FAnchorpointSourceControlState> State = StaticCastSharedPtr<FAnchorpointSourceControlState>(PackageState);
+
+	if (State->State == EAnchorpointState::Added)
 	{
-		// Re-saving an added asset won't change its state. It might change it from AddedInMemory to Added (on disk) but nothing else.
+		// Re-saving an added asset won't change its state.
+		return true;
+	}
+
+	if (State->State == EAnchorpointState::AddedInMemory)
+	{
+		// Re-saving AddedInMemory will change state to added once it is saved on disk, so make sure it's part of the status
 		if (!InOutStatus.Staged.Contains(InPackageFilename) && !InOutStatus.NotStaged.Contains(InPackageFilename))
 		{
 			InOutStatus.NotStaged.Add(InPackageFilename, EAnchorpointFileOperation::Added);
@@ -616,12 +624,17 @@ bool FAnchorpointSourceControlProvider::OnAssetSavedPatchStatus(FAnchorpointStat
 		return true;
 	}
 
-	if (!State->IsModified())
+	if (State->State == EAnchorpointState::LockedModified || State->State == EAnchorpointState::UnlockedModified)
 	{
-		// Re-saving an unchanged asset will certainly mark it as modified.
-		InOutStatus.NotStaged.Add(InPackageFilename, EAnchorpointFileOperation::Modified);
-
+		// Re-saving an already modified asset will only keep it modified.
 		return true;
+	}
+
+	if (State->State == EAnchorpointState::UnlockedUnchanged)
+	{
+		// Re-saving an unchanged asset will certainly mark it as modified. 
+		// At this point we cannot reason if it's LockedModified or UnlockedModified.
+		InOutStatus.NotStaged.Add(InPackageFilename, EAnchorpointFileOperation::Modified);
 	}
 
 	return false;

--- a/Source/Anchorpoint/Public/AnchorpointSourceControlProvider.h
+++ b/Source/Anchorpoint/Public/AnchorpointSourceControlProvider.h
@@ -92,6 +92,10 @@ public:
 	 * Tries to patch the cached status when a message is received.
 	 */
 	bool OnMessageReceivedPatchStatus(FAnchorpointStatus& InOutStatus, const FAnchorpointConnectMessage& InMessage);
+	/**
+	 * Tries to patch the cached status when an asset is created in memory (e.g. via duplication).
+	 */
+	bool OnInMemoryAssetCreatedPatchStatus(FAnchorpointStatus& InOutStatus, UObject* InAsset);
 
 	void OutputCommandMessages(const FAnchorpointSourceControlCommand& InCommand) const;
 	TSharedPtr<IAnchorpointSourceControlWorker> CreateWorker(const FName& OperationName);

--- a/Source/Anchorpoint/Public/AnchorpointSourceControlProvider.h
+++ b/Source/Anchorpoint/Public/AnchorpointSourceControlProvider.h
@@ -9,6 +9,8 @@
 class FAnchorpointSourceControlState;
 class FAnchorpointSourceControlCommand;
 class IAnchorpointSourceControlWorker;
+struct FAnchorpointStatus;
+struct FAnchorpointConnectMessage;
 
 class FAnchorpointSourceControlProvider : public ISourceControlProvider
 {
@@ -81,6 +83,15 @@ public:
 	FDateTime GetLastSyncTime() const;
 
 	TMap<FString, TSharedRef<FAnchorpointSourceControlState>> StateCache;
+
+	/**
+	 * Tries to patch the cached status when an asset is saved.
+	 */
+	bool OnAssetSavedPatchStatus(FAnchorpointStatus& InOutStatus, const FString& InPackageFilename);
+	/**
+	 * Tries to patch the cached status when a message is received.
+	 */
+	bool OnMessageReceivedPatchStatus(FAnchorpointStatus& InOutStatus, const FAnchorpointConnectMessage& InMessage);
 
 	void OutputCommandMessages(const FAnchorpointSourceControlCommand& InCommand) const;
 	TSharedPtr<IAnchorpointSourceControlWorker> CreateWorker(const FName& OperationName);

--- a/Source/Anchorpoint/Public/AnchorpointSourceControlProvider.h
+++ b/Source/Anchorpoint/Public/AnchorpointSourceControlProvider.h
@@ -70,6 +70,10 @@ public:
 	virtual TSharedRef<SWidget> MakeSettingsWidget() const override;
 	//~ End ISourceControlProvider Interface
 
+	/**
+	 * Executed when the `Connect` source control command is executed by Anchorpoint
+	 */
+	void OnConnected();
 	void OnStatesChanged();
 	void TickDuringModal(float DeltaTime);
 
@@ -87,9 +91,8 @@ public:
 
 	FSourceControlStateChanged OnSourceControlStateChanged;
 	TArray<FAnchorpointSourceControlCommand*> CommandQueue;
-	
-	FText GetPromptTextForOperation(const FSourceControlOperationRef& InOperation) const;
 
+	FText GetPromptTextForOperation(const FSourceControlOperationRef& InOperation) const;
 
 	enum class EActiveModalState
 	{

--- a/Source/AnchorpointCli/AnchorpointCli.Build.cs
+++ b/Source/AnchorpointCli/AnchorpointCli.Build.cs
@@ -8,6 +8,7 @@ public class AnchorpointCli : ModuleRules
 	{
 		PrivateDependencyModuleNames.AddRange(new[]
 		{
+			"AssetRegistry",
 			"Core",
 			"CoreUObject",
 			"EditorScriptingUtilities",

--- a/Source/AnchorpointCli/Private/AnchorpointCliConnectSubsystem.cpp
+++ b/Source/AnchorpointCli/Private/AnchorpointCliConnectSubsystem.cpp
@@ -127,6 +127,11 @@ bool UAnchorpointCliConnectSubsystem::IsProjectConnected() const
 	return IsCliConnected() && bCanUseStatusCache;
 }
 
+void UAnchorpointCliConnectSubsystem::RefreshConnection()
+{
+	TickConnection();
+}
+
 void UAnchorpointCliConnectSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 {
 	Super::Initialize(Collection);
@@ -134,8 +139,6 @@ void UAnchorpointCliConnectSubsystem::Initialize(FSubsystemCollectionBase& Colle
 	UPackage::PackageSavedWithContextEvent.AddUObject(this, &UAnchorpointCliConnectSubsystem::HandlePackageSaved);
 
 	FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UAnchorpointCliConnectSubsystem::Tick), 30.0f);
-
-	FAnchorpointCliModule::Get().OnAnchorpointConnected.AddUObject(this, &UAnchorpointCliConnectSubsystem::OnAnchorpointProviderConnected);
 
 	FakeAnchorpointCliMessage = IConsoleManager::Get().RegisterConsoleCommand(
 		TEXT("FakeAnchorpointCliMessage"),
@@ -380,12 +383,6 @@ void UAnchorpointCliConnectSubsystem::StopSync(const FAnchorpointConnectMessage&
 
 	bSyncInProgress = false;
 	RespondToMessage(Message.Id);
-}
-
-void UAnchorpointCliConnectSubsystem::OnAnchorpointProviderConnected()
-{
-	// Extra ticks in case a relevant event happened.
-	TickConnection();
 }
 
 void UAnchorpointCliConnectSubsystem::HandleMessage(const FAnchorpointConnectMessage& Message)

--- a/Source/AnchorpointCli/Private/AnchorpointCliConnectSubsystem.cpp
+++ b/Source/AnchorpointCli/Private/AnchorpointCliConnectSubsystem.cpp
@@ -15,6 +15,8 @@
 #include <Widgets/Notifications/SNotificationList.h>
 #include <UObject/ObjectSaveContext.h>
 #include <LevelEditor.h>
+#include <AssetRegistry/AssetRegistryModule.h>
+#include <AssetRegistry/IAssetRegistry.h>
 
 #include "AnchorpointCli.h"
 #include "AnchorpointCliLog.h"
@@ -137,6 +139,9 @@ void UAnchorpointCliConnectSubsystem::Initialize(FSubsystemCollectionBase& Colle
 	Super::Initialize(Collection);
 
 	UPackage::PackageSavedWithContextEvent.AddUObject(this, &UAnchorpointCliConnectSubsystem::HandlePackageSaved);
+
+	IAssetRegistry& AssetRegistry = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry").Get();
+	AssetRegistry.OnInMemoryAssetCreated().AddUObject(this, &UAnchorpointCliConnectSubsystem::HandleInMemoryAssetCreated);
 
 	FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UAnchorpointCliConnectSubsystem::Tick), 30.0f);
 
@@ -637,6 +642,15 @@ void UAnchorpointCliConnectSubsystem::HandlePackageSaved(const FString& InPackag
 		RefreshStatus(bCanUseStatusCache, {});
 	});
 	GEditor->GetTimerManager()->SetTimer(RefreshTimerHandle, RefreshDelegate, RefreshDelay, false);
+}
+
+void UAnchorpointCliConnectSubsystem::HandleInMemoryAssetCreated(UObject* InAsset)
+{
+	if (TryPatchStatus(OnInMemoryAssetCreatedPatchStatus, InAsset))
+	{
+		UE_LOG(LogAnchorpointCli, Verbose, TEXT("CachedStatus was patched for in-memory asset: %s"), *InAsset->GetPathName());
+		RefreshStatus(false, {});
+	}
 }
 
 const FSlateBrush* UAnchorpointCliConnectSubsystem::GetDrawerIcon() const

--- a/Source/AnchorpointCli/Private/AnchorpointCliConnectSubsystem.cpp
+++ b/Source/AnchorpointCli/Private/AnchorpointCliConnectSubsystem.cpp
@@ -252,83 +252,6 @@ TOptional<FString> UAnchorpointCliConnectSubsystem::CheckProjectSaveStatus(const
 	return !ErrorMessage.IsEmpty() ? ErrorMessage : TOptional<FString>();
 }
 
-bool UAnchorpointCliConnectSubsystem::PatchCachedStatusOnPackageSave(const FString& InPackageFilename)
-{
-	FScopeLock ScopeLock(&StatusCacheLock);
-
-	if (!StatusCache)
-	{
-		return false; // No cache available to patch
-	}
-
-	ISourceControlProvider& Provider = ISourceControlModule::Get().GetProvider();
-	FSourceControlStatePtr State = Provider.GetState(InPackageFilename, EStateCacheUsage::Use);
-
-	if (!State)
-	{
-		return false; // We cannot reason about this asset without knowing it's state.
-	}
-
-	if (State->IsAdded())
-	{
-		// Re-saving an added asset won't change its state. It might change it from AddedInMemory to Added (on disk) but nothing else.
-		if (!StatusCache->Staged.Contains(InPackageFilename) && !StatusCache->NotStaged.Contains(InPackageFilename))
-		{
-			StatusCache->NotStaged.Add(InPackageFilename, EAnchorpointFileOperation::Added);
-		}
-
-		return true;
-	}
-
-	if (!State->IsModified())
-	{
-		// Re-saving an unchanged asset will certainly mark it as modified.
-		StatusCache->NotStaged.Add(InPackageFilename, EAnchorpointFileOperation::Modified);
-
-		return true;
-	}
-
-	return false;
-}
-
-bool UAnchorpointCliConnectSubsystem::PatchCachedStatusOnLockUpdate()
-{
-	FScopeLock ScopeLock(&StatusCacheLock);
-
-	if (!StatusCache)
-	{
-		return false; // No cache available to patch
-	}
-
-	TValueOrError<FAnchorpointLocks, FString> Locks = AnchorpointCliOperations::GetLockedFiles();
-	if (!Locks.HasValue())
-	{
-		return false; // Command failed, no usable result available
-	}
-
-	StatusCache->Locked = Locks.GetValue();
-	return true;
-}
-
-bool UAnchorpointCliConnectSubsystem::PatchCachedStatusOnOutdatedUpdate()
-{
-	FScopeLock ScopeLock(&StatusCacheLock);
-
-	if (!StatusCache)
-	{
-		return false; // No cache available to patch
-	}
-
-	TValueOrError<FAnchorpointOutdated, FString> Outdated = AnchorpointCliOperations::GetOutdatedFiles();
-	if (!Outdated.HasValue())
-	{
-		return false; // Command failed, no usable result available
-	}
-
-	StatusCache->Outdated = Outdated.GetValue();
-	return true;
-}
-
 void UAnchorpointCliConnectSubsystem::StartSync(const FAnchorpointConnectMessage& Message)
 {
 	if (bSyncInProgress)
@@ -472,24 +395,11 @@ void UAnchorpointCliConnectSubsystem::HandleMessage(const FAnchorpointConnectMes
 
 	OnPreMessageHandled.Broadcast(Message);
 
-	if (MessageType == TEXT("files locked") || MessageType == TEXT("files unlocked"))
+	if (MessageType == TEXT("files locked") || MessageType == TEXT("files unlocked") || MessageType == TEXT("files outdated") || MessageType == TEXT("files updated"))
 	{
-		if (PatchCachedStatusOnLockUpdate())
+		if (TryPatchStatus(OnMessageReceivedPatchStatus, Message))
 		{
-			UE_LOG(LogAnchorpointCli, Verbose, TEXT("Cached Status was patched for Locked Files Message: %s"), *MessageType);
-			RefreshStatus(false, {});
-		}
-		else
-		{
-			ClearStatusCache();
-			RefreshStatus(bCanUseStatusCache, bCanUseStatusCache ? TArray<FString>() : Message.Files);
-		}
-	}
-	else if (MessageType == TEXT("files outdated") || MessageType == TEXT("files updated"))
-	{
-		if (PatchCachedStatusOnOutdatedUpdate())
-		{
-			UE_LOG(LogAnchorpointCli, Verbose, TEXT("Cached Status was patched for Outdated Files Message: %s"), *MessageType);
+			UE_LOG(LogAnchorpointCli, Verbose, TEXT("Cached Status was patched for Message: %s"), *MessageType);
 			RefreshStatus(false, {});
 		}
 		else
@@ -713,7 +623,7 @@ void UAnchorpointCliConnectSubsystem::OnLevelEditorCreated(TSharedPtr<ILevelEdit
 
 void UAnchorpointCliConnectSubsystem::HandlePackageSaved(const FString& InPackageFilename, UPackage* InPackage, FObjectPostSaveContext InObjectSaveContext)
 {
-	if (PatchCachedStatusOnPackageSave(InPackageFilename))
+	if (TryPatchStatus(OnAssetSavedPatchStatus, InPackageFilename))
 	{
 		UE_LOG(LogAnchorpointCli, Verbose, TEXT("CachedStatus was patched for Saved Package: %s"), *InPackageFilename);
 		RefreshStatus(false, {});

--- a/Source/AnchorpointCli/Public/AnchorpointCli.h
+++ b/Source/AnchorpointCli/Public/AnchorpointCli.h
@@ -17,9 +17,4 @@ public:
 	FString GetApplicationPath() const;
 
 	bool IsCurrentProvider() const;
-
-	/**
-	 * Delegate executed when the `Connect` source control command is executed by Anchorpoint
-	 */
-	FSimpleMulticastDelegate OnAnchorpointConnected;
 };

--- a/Source/AnchorpointCli/Public/AnchorpointCliConnectSubsystem.h
+++ b/Source/AnchorpointCli/Public/AnchorpointCliConnectSubsystem.h
@@ -88,6 +88,10 @@ public:
 	 * Checks if the integration has the project currently connected to the Anchorpoint CLI
 	 */
 	bool IsProjectConnected() const; 
+	/**
+	 * Called externally when something relevant happened to refresh the connection immediately
+	 */
+	void RefreshConnection();
 
 private:
 	//~ Begin UEditorSubsystem Interface
@@ -124,10 +128,6 @@ private:
 	 */
 	void StopSync(const FAnchorpointConnectMessage& Message);
 
-	/**
-	 * Callback executed when the Anchorpoint Source Control Provider is initialized
-	 */
-	void OnAnchorpointProviderConnected();
 	/**
 	 * Callback executed when a message is received from the Anchorpoint CLI
 	 */

--- a/Source/AnchorpointCli/Public/AnchorpointCliConnectSubsystem.h
+++ b/Source/AnchorpointCli/Public/AnchorpointCliConnectSubsystem.h
@@ -81,6 +81,11 @@ public:
 	using FOnMessageReceivedPatchStatus = TDelegate<bool(FAnchorpointStatus& InOutStatus, const FAnchorpointConnectMessage& InMessage)>;
 	FOnMessageReceivedPatchStatus OnMessageReceivedPatchStatus;
 	/**
+	 * Delegate executed when an asset is created in memory allowing implementer to patch the cached status instead of refreshing it
+	 */
+	using FOnInMemoryAssetCreatedPatchStatus = TDelegate<bool(FAnchorpointStatus& InOutStatus, UObject* InAsset)>;
+	FOnInMemoryAssetCreatedPatchStatus OnInMemoryAssetCreatedPatchStatus;
+	/**
 	 * Checks if the integration is currently connected to the Anchorpoint CLI
 	 */
 	bool IsCliConnected() const;
@@ -161,9 +166,13 @@ private:
 	 */
 	void OnLevelEditorCreated(TSharedPtr<ILevelEditor> LevelEditor);
 	/**
-	 * Callback executed when a package (asset or actor) is saved to disk 
+	 * Callback executed when a package (asset or actor) is saved to disk
 	 */
 	void HandlePackageSaved(const FString& InPackageFilename, UPackage* InPackage, FObjectPostSaveContext InObjectSaveContext);
+	/**
+	 * Callback executed when an asset is created in memory (e.g. via duplication) before it is ever saved to disk
+	 */
+	void HandleInMemoryAssetCreated(UObject* InAsset);
 	/**
 	 * Callback executed to determine what icon should be shown next to the revision control status bar
 	 */

--- a/Source/AnchorpointCli/Public/AnchorpointCliConnectSubsystem.h
+++ b/Source/AnchorpointCli/Public/AnchorpointCliConnectSubsystem.h
@@ -71,6 +71,16 @@ public:
 	 */
 	TMulticastDelegate<void(const FAnchorpointConnectMessage& InMessage)> OnPreMessageHandled;
 	/**
+	 * Delegate executed when an asset is saved allowing implementer to patch the cached status instead of refreshing it
+	 */
+	using FOnAssetSavedPatchStatus = TDelegate<bool(FAnchorpointStatus& InOutStatus, const FString& InPackageFilename)>;
+	FOnAssetSavedPatchStatus OnAssetSavedPatchStatus;
+	/**
+	 * Delegate executed when a message is received allowing implementer to patch the cached status instead of refreshing it
+	 */
+	using FOnMessageReceivedPatchStatus = TDelegate<bool(FAnchorpointStatus& InOutStatus, const FAnchorpointConnectMessage& InMessage)>;
+	FOnMessageReceivedPatchStatus OnMessageReceivedPatchStatus;
+	/**
 	 * Checks if the integration is currently connected to the Anchorpoint CLI
 	 */
 	bool IsCliConnected() const;
@@ -101,18 +111,6 @@ private:
 	 * Checks if the project has been saved and if not, returns an error message
 	 */
 	TOptional<FString> CheckProjectSaveStatus(const TArray<FString>& Files);
-	/*
-	 * Tries to patch the cached status when an asset is saved.
-	 */
-	bool PatchCachedStatusOnPackageSave(const FString& InPackageFilename);
-	/*
-	 * Tries to patch the cached status when locked files are updated.
-	 */
-	bool PatchCachedStatusOnLockUpdate();
-	/*
-	 * Tries to patch the cached status when outdated files are updated.
-	 */
-	bool PatchCachedStatusOnOutdatedUpdate();
 	/**
 	 * Stats the sync process by unlinking the files in the message
 	 */
@@ -174,6 +172,21 @@ private:
 	 * Callback executed to determine what tooltip text should be shown for the icon next to the revision control status bar 
 	 */
 	FText GetDrawerText() const;
+	template <typename... DelegateArgs, typename... CallArgs>
+	/**
+	 * Safely runs delegates which need to modify the cached status or early outs if not possible
+	 */
+	bool TryPatchStatus(const TDelegate<bool(FAnchorpointStatus&, DelegateArgs...)>& Delegate, CallArgs&&... FuncArgs)
+	{
+		if (!Delegate.IsBound() || !StatusCache)
+		{
+			return false;
+		}
+
+		FScopeLock ScopeLock(&StatusCacheLock);
+		return Delegate.Execute(*StatusCache, Forward<CallArgs>(FuncArgs)...);
+	}
+
 	/**
 	 * The process that is running the Anchorpoint CLI connect command
 	 */


### PR DESCRIPTION
Main goal was to move the 3 patching functions from `UAnchorpointCliConnectSubsystem`:

- `PatchCachedStatusOnPackageSave`
- `PatchCachedStatusOnLockUpdate`
- `PatchCachedStatusOnOutdatedUpdate`

To the `FAnchorpointSourceControlProvider`

This was required so their implementation are part of `Anchorpoint` (instead of `AnchorpointCLI` module) so they can access the glorified `FAnchorpointSourceControlState::State`.

Based on that we can do much better patching such as:

```
if (!State->IsModified()) // which internall checks for Added, AddedInMemory, LockedModified, LockedDeleted, UnlockedModified, UnlockedDeleted, OutDatedLockedModified, OutDatedUnlockedModified
```

with precise checks like:
```
if (State->State == EAnchorpointState::LockedModified || State->State == EAnchorpointState::UnlockedModified)
{
	// Re-saving an already modified asset will only keep it modified.
	return true;
}

if (State->State == EAnchorpointState::UnlockedUnchanged)
{
	// Re-saving an unchanged asset will certainly mark it as modified. 
	InOutStatus.NotStaged.Add(InPackageFilename, EAnchorpointFileOperation::Modified);
}
```